### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         ELASTICSEARCH_VERSION: 7.8.1
         JIEBAPLUGIN_VERSION: 7.8.1


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore